### PR TITLE
feat: Add timeZone configuration to CronJob manifests.

### DIFF
--- a/charts/mf-dashboard/templates/cronjob.yaml
+++ b/charts/mf-dashboard/templates/cronjob.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/component: crawler
 spec:
   schedule: {{ $schedule.cron | quote }}
+  timeZone: {{ $schedule.timeZone | default $.Values.cronjob.timeZone | quote }}
   concurrencyPolicy: {{ $.Values.cronjob.concurrencyPolicy }}
   successfulJobsHistoryLimit: {{ $.Values.cronjob.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ $.Values.cronjob.failedJobsHistoryLimit }}

--- a/charts/mf-dashboard/values.yaml
+++ b/charts/mf-dashboard/values.yaml
@@ -35,11 +35,13 @@ web:
 
 # CronJob 設定
 cronjob:
+  timeZone: "Asia/Tokyo"
   schedules:
     - cron: "30 10 * * *" # JST 10:30
       skipRefresh: false
-    - cron: "30 18 * * *" # JST 18:30
+    - cron: "30 18 * * *" # UTC 18:30
       skipRefresh: true
+      timeZone: "UTC"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
This pull request introduces improvements to the CronJob configuration in the Helm chart for `mf-dashboard`, focusing on enhanced time zone support and clarity in scheduling. The most important changes include adding explicit time zone settings for scheduled jobs and updating the default time zone.

CronJob time zone enhancements:

* Added a `timeZone` field to the CronJob template (`cronjob.yaml`) to allow specifying the time zone for each schedule, improving accuracy and flexibility in job execution times.
* Updated the default CronJob time zone in `values.yaml` to `"Asia/Tokyo"`, ensuring that scheduled jobs use the correct local time unless overridden.
* Modified one schedule to explicitly use `"UTC"` as its time zone, clarifying the intended execution time and preventing confusion.